### PR TITLE
improved resource-url extraction from script tag

### DIFF
--- a/src/compiler/component-lazy/generate-lazy-app.ts
+++ b/src/compiler/component-lazy/generate-lazy-app.ts
@@ -124,7 +124,7 @@ function getLegacyLoader(config: d.Config) {
   const namespace = config.fsNamespace;
   return `
 (function(doc){
-  var scriptElm = doc.scripts[doc.scripts.length - 1];
+  var scriptElm = doc.querySelector('script[data-resources-url]') || doc.scripts[doc.scripts.length - 1];
   var warn = ['[${namespace}] Deprecated script, please remove: ' + scriptElm.outerHTML];
 
   warn.push('To improve performance it is recommended to set the differential scripts in the head as follows:')


### PR DESCRIPTION
Current code only get last script tag from the document and use it as source for stencil component which in my case is not a valid location for stencil component. I have updated the code with the previously added data attribute 'data-resource-url' and i am querying the script tag which contains the data-resource-url to get valid path for stencil component lazy loading. 

The current code enforces developers to only add the script at the end of the document and it does not work a lot of time when the scripts are being injected by CI or other scripts and it keep on breaking and generating invalid src for stencil component script.